### PR TITLE
Some changes and simplifications; see note.

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,6 +46,14 @@ def run_lift(lift, graph, n, octset, partial):
     return avgtime, minsol, maxsol
 
 
+def is_yaml(file):
+    return file.lower().endswith('.yaml')
+
+
+def is_s6(file):
+    return file.lower().endswith('.s6')
+
+
 def main():
     # parse config
     config_args = parse_config()
@@ -196,11 +204,8 @@ def parse_config():
     lifts = ['greedy', 'naive']
     approx = ['dfs', 'heuristic', 'std']
 
-    print(1)
-
     parser = argparse.ArgumentParser(prog='main.py', usage='%(prog)s',
-        description='Structural Rounding - Experimental Harness',
-        epilog='')
+        description='Structural Rounding - Experimental Harness')
     parser.add_argument('-p', '--problem', choices=problems, help='the problem')
     parser.add_argument('-c', '--class', dest='gclass', choices=classes, help='the graph class to edit to')
     parser.add_argument('-e', '--edit', choices=edits, help='the editing algorithm')
@@ -210,10 +215,7 @@ def parse_config():
     parser.add_argument('-s', '--spec', nargs='?', const='config.yaml', help='the optional config (.yaml) file')
     parser.add_argument('-r', '--results', nargs='?', const='results.csv', help='the results (.csv) file')
     parser.add_argument('-v', '--version', action='version', version='%(prog)s Alpha v1.0')
-    print(2)
     config_args = parser.parse_args()
-
-    print(3)
 
     if config_args.spec is not None:
         if is_yaml(config_args.spec):
@@ -241,32 +243,7 @@ def parse_config():
         print(usage_error(parser, '-r/--results', 'expected one argument'))
         exit(1)
 
-    # check that optional arguments are within their choices
-    if config_args.problem not in problems:
-        print(usage_error(parser, '-p/--problem', 'invalid choice', problems))
-        exit(1)
-    if config_args.gclass not in classes:
-        print(usage_error(parser, '-c/--class', 'invalid choice', classes))
-        exit(1)
-    if config_args.edit not in edits:
-        print(usage_error(parser, '-e/--edit', 'invalid choice', edits))
-        exit(1)
-    if config_args.lift not in lifts:
-        print(usage_error(parser, '-l/--lift', 'invalid choice', lifts))
-        exit(1)
-    if config_args.approx not in approx:
-        print(usage_error(parser, '-a/--approx', 'invalid choice', approx))
-        exit(1)
-
     return config_args
-
-
-def is_yaml(file):
-    return file.lower().endswith('.yaml')
-
-
-def is_s6(file):
-    return file.lower().endswith('.s6')
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -186,7 +186,7 @@ def usage_error(parser, argument, info, choices=None):
     if choices is None:
         return parser.prog + ': error: argument ' + argument + ': ' + info
     else:
-        return parser.prog + ': error: argument ' + argument + ': ' + info + ' (choose from ' + choices + ')'
+        return parser.prog + ': error: argument ' + argument + ': ' + info + ' (choose from ' + str(choices) + ')'
 
 
 def parse_config():
@@ -195,6 +195,8 @@ def parse_config():
     edits = ['remove_octset']
     lifts = ['greedy', 'naive']
     approx = ['dfs', 'heuristic', 'std']
+
+    print(1)
 
     parser = argparse.ArgumentParser(prog='main.py', usage='%(prog)s',
         description='Structural Rounding - Experimental Harness',
@@ -208,7 +210,10 @@ def parse_config():
     parser.add_argument('-s', '--spec', nargs='?', const='config.yaml', help='the optional config (.yaml) file')
     parser.add_argument('-r', '--results', nargs='?', const='results.csv', help='the results (.csv) file')
     parser.add_argument('-v', '--version', action='version', version='%(prog)s Alpha v1.0')
+    print(2)
     config_args = parser.parse_args()
+
+    print(3)
 
     if config_args.spec is not None:
         if is_yaml(config_args.spec):
@@ -229,36 +234,28 @@ def parse_config():
     if config_args.problem is None:
         print(usage_error(parser, '-p/--problem', 'expected one argument'))
         exit(1)
-    if config_args.problem is not None and config_args.problem != 'vertex_cover':
-        print('foobar')
-        # print(usage_error(parser, '-p/--problem', 'invalid choice', problems))
-        # print('usage: ' + parser.prog + '\n' + parser.prog + ': error: argument -p/--problem: invalid choice: \'' + config_args.problem + '\' (choose from \'vertex_cover\')')
-        exit(1)
-
-
     if config_args.graph is None:
-        print('usage: ' + parser.prog + '\n' + parser.prog + ': error: argument -g/--graph: expected one argument')
+        print(usage_error(parser, '-g/--graph', 'expected one argument'))
         exit(1)
     if config_args.results is None:
-        print('usage: ' + parser.prog + '\n' + parser.prog + ': error: argument -r/--results: expected one argument')
+        print(usage_error(parser, '-r/--results', 'expected one argument'))
         exit(1)
 
     # check that optional arguments are within their choices
-    if config_args.problem is not None and config_args.problem != 'vertex_cover':
-        # print(usage_error(parser, '-p/--problem', 'invalid choice', problems))
-        # print('usage: ' + parser.prog + '\n' + parser.prog + ': error: argument -p/--problem: invalid choice: \'' + config_args.problem + '\' (choose from \'vertex_cover\')')
+    if config_args.problem not in problems:
+        print(usage_error(parser, '-p/--problem', 'invalid choice', problems))
         exit(1)
-    if config_args.gclass is not None and config_args.gclass != 'bipartite':
-        print('usage: ' + parser.prog + '\n' + parser.prog + ': error: argument -c/--class: invalid choice: \'' + config_args.gclass + '\' (choose from \'bipartite\')')
+    if config_args.gclass not in classes:
+        print(usage_error(parser, '-c/--class', 'invalid choice', classes))
         exit(1)
-    if config_args.edit is not None and config_args.edit != 'remove_octset':
-        print('usage: ' + parser.prog + '\n' + parser.prog + ': error: argument -e/--edit: invalid choice: \'' + config_args.edit + '\' (choose from \'remove_octset\')')
+    if config_args.edit not in edits:
+        print(usage_error(parser, '-e/--edit', 'invalid choice', edits))
         exit(1)
-    if config_args.lift is not None and config_args.lift != 'greedy' and config_args.lift != 'naive':
-        print('usage: ' + parser.prog + '\n' + parser.prog + ': error: argument -l/--lift: invalid choice: \'' + config_args.lift + '\' (choose from \'greedy\', \'naive\')')
+    if config_args.lift not in lifts:
+        print(usage_error(parser, '-l/--lift', 'invalid choice', lifts))
         exit(1)
-    if config_args.approx is not None and config_args.approx != 'dfs' and config_args.approx != 'heuristic' and config_args.approx != 'std':
-        print('usage: ' + parser.prog + '\n' + parser.prog + ': error: argument -a/--approx: invalid choice: \'' + config_args.approx + '\' (choose from \'dfs\', \'heuristic\', \'std\')')
+    if config_args.approx not in approx:
+        print(usage_error(parser, '-a/--approx', 'invalid choice', approx))
         exit(1)
 
     return config_args

--- a/main.py
+++ b/main.py
@@ -190,8 +190,12 @@ def main():
                 print()
 
 
-def one_arg_err(parser, argument):
-    return 'usage: ' + parser.prog + '\n' + parser.prog + ': error: argument ' + argument + ': expected one argument'
+def usage_error(parser, argument, choice=None, lists=[]):
+    res = 'usage: ' + parser.prog + '\n' + parser.prog + ': error: argument ' + argument
+    if choice is None:
+        return res + ': expected one argument'
+    else:
+        return res + ': invalid choice: \'' + choice + '\' (choose from ' + str(lists)[1:-1] + ')'
 
 
 def parse_config():
@@ -231,13 +235,30 @@ def parse_config():
 
     # check that required arguments exist
     if config_args.problem is None:
-        print(one_arg_err(parser, '-p/--problem'))
+        print(usage_error(parser, '-p/--problem'))
         exit(1)
     if config_args.graph is None:
-        print(one_arg_err(parser, '-g/--graph'))
+        print(usage_error(parser, '-g/--graph'))
         exit(1)
     if config_args.results is None:
-        print(one_arg_err(parser, '-r/--results'))
+        print(usage_error(parser, '-r/--results'))
+        exit(1)
+
+    # check that optional arguments are within their choices
+    if config_args.problem not in problems:
+        print(usage_error(parser, '-p/--problem', config_args.problem, problems))
+        exit(1)
+    if config_args.gclass not in classes:
+        print(usage_error(parser, '-c/--class', config_args.gclass, classes))
+        exit(1)
+    if config_args.approx not in approx:
+        print(usage_error(parser, '-a/--approx', config_args.approx, approx))
+        exit(1)
+    if config_args.edit not in edits:
+        print(usage_error(parser, '-e/--edit', config_args.edit, edits))
+        exit(1)
+    if config_args.lift not in lifts:
+        print(usage_error(parser, '-l/--lift', config_args.lift, lifts))
         exit(1)
 
     return config_args

--- a/main.py
+++ b/main.py
@@ -265,11 +265,11 @@ def parse_config():
 
 
 def is_yaml(file):
-    return file.lower().endswith(('.yaml'))
+    return file.lower().endswith('.yaml')
 
 
 def is_s6(file):
-    return file.lower().endswith(('.s6'))
+    return file.lower().endswith('.s6')
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -230,6 +230,7 @@ def parse_config():
         print(usage_error(parser, '-p/--problem', 'expected one argument'))
         exit(1)
     if config_args.problem is not None and config_args.problem != 'vertex_cover':
+        print('foobar')
         # print(usage_error(parser, '-p/--problem', 'invalid choice', problems))
         # print('usage: ' + parser.prog + '\n' + parser.prog + ': error: argument -p/--problem: invalid choice: \'' + config_args.problem + '\' (choose from \'vertex_cover\')')
         exit(1)

--- a/main.py
+++ b/main.py
@@ -190,11 +190,8 @@ def main():
                 print()
 
 
-def usage_error(parser, argument, info, choices=None):
-    if choices is None:
-        return parser.prog + ': error: argument ' + argument + ': ' + info
-    else:
-        return parser.prog + ': error: argument ' + argument + ': ' + info + ' (choose from ' + str(choices) + ')'
+def one_arg_err(parser, argument):
+    return 'usage: ' + parser.prog + '\n' + parser.prog + ': error: argument ' + argument + ': expected one argument'
 
 
 def parse_config():
@@ -234,13 +231,13 @@ def parse_config():
 
     # check that required arguments exist
     if config_args.problem is None:
-        print(usage_error(parser, '-p/--problem', 'expected one argument'))
+        print(one_arg_err(parser, '-p/--problem'))
         exit(1)
     if config_args.graph is None:
-        print(usage_error(parser, '-g/--graph', 'expected one argument'))
+        print(one_arg_err(parser, '-g/--graph'))
         exit(1)
     if config_args.results is None:
-        print(usage_error(parser, '-r/--results', 'expected one argument'))
+        print(one_arg_err(parser, '-r/--results'))
         exit(1)
 
     return config_args


### PR DESCRIPTION
Some changes I have made:

1. Removed `random` relevant codes since @BrianLavallee told me that they were not necessary anymore.

2. Simplified `is_yaml` and `is_s6` so that they are more "Pythonic". I defined `one_arg_err` to simplify some `print` statements.

3. I abstracted `problems`, `classes`, `edits`, `lifts`, and `approx` into lists, so that it would be easier to extend in the future without making changes to too many lines.

4. Removed `print` statements that involved `invalid_choice`, since `argparse` would automatically print these out if wrong arguments are given.